### PR TITLE
chore: Adding the liveness and readiness probes to the redis server

### DIFF
--- a/discovery_template.yaml
+++ b/discovery_template.yaml
@@ -380,6 +380,22 @@ objects:
             ports:
               - containerPort: ${{DISCOVERY_REDIS_PORT}}
                 protocol: TCP
+            livenessProbe:
+              tcpSocket:
+                port: ${{DISCOVERY_REDIS_PORT}}
+              initialDelaySeconds: 30
+              timeoutSeconds: 5
+              periodSeconds: 5
+              failureThreshold: 5
+              successThreshold: 1
+            readinessProbe:
+              exec:
+                command:
+                - redis-cli
+                - ping
+              initialDelaySeconds: 20
+              timeoutSeconds: 5
+              periodSeconds: 3
             env:
               - name: REDIS_PASSWORD
                 value: "qpc"


### PR DESCRIPTION

chore: Adding the liveness and readiness probes to the redis server

Was missing them in discovery-redis. Using the probes that have been used in redis productions.